### PR TITLE
add some badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 
-# corels
+# corels: R interface to 'Certifiably Optimal RulE ListS' (Corels)
 
-R interface to 'Certifiably Optimal RulE ListS' (Corels)
+[![Build Status](https://travis-ci.org/eddelbuettel/rcppcorels.svg)](https://travis-ci.org/eddelbuettel/rcppcorels)
+[![License](https://eddelbuettel.github.io/badges/GPL2+.svg)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![CRAN](http://www.r-pkg.org/badges/version/corels)](https://cran.r-project.org/package=corels)
+[![Dependencies](https://tinyverse.netlify.com/badge/corels)](https://cran.r-project.org/package=corels)
+[![Downloads](http://cranlogs.r-pkg.org/badges/corels?color=brightgreen)](http://www.r-pkg.org/pkg/corels)
 
 ## What is it?
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # corels: R interface to 'Certifiably Optimal RulE ListS' (Corels)
 
-[![Build Status](https://travis-ci.org/eddelbuettel/rcppcorels.svg)](https://travis-ci.org/eddelbuettel/rcppcorels)
+[![Build Status](https://travis-ci.org/corels/rcppcorels.svg)](https://travis-ci.org/corels/rcppcorels)
 [![License](https://eddelbuettel.github.io/badges/GPL2+.svg)](http://www.gnu.org/licenses/gpl-2.0.html)
 [![CRAN](http://www.r-pkg.org/badges/version/corels)](https://cran.r-project.org/package=corels)
 [![Dependencies](https://tinyverse.netlify.com/badge/corels)](https://cran.r-project.org/package=corels)


### PR DESCRIPTION
This adds some badges which I like for my repos -- happy to discuss / adapt style or content if there are proposals.  The PR would make it look like

![image](https://user-images.githubusercontent.com/673121/83943394-4ff1e100-a7c1-11ea-9d2c-56bb90d2bacc.png)

(Screenshot from `atom` to render markdown, dark theme is editor-specific).

Also, we probably need to hook up this 'corels' org with Travis to have the commits tickle continuous integration runs.  There may currently something up between GitHub and Travis -- for the last few days I have only seen repos from 'eddelbuettel' in Travis but not from RcppCore, work, this repo, ...  That happened once before and somehow fixed itself, I was under the impression it is "them".